### PR TITLE
added LIBPERL_CCFLAGS env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ via `PERL` environment variable
 
     $ PERL=/opt/bin/custom-perl cargo build
 
+Under rare circumstances you may need to modify the ccflags for libperl.
+    Run perl -MConfig -e 'print $Config::Config{ccflags}'
+    Modify these flags as necessary, and override via the LIBPERL_CCFLAGS environment variable.
+
+    $ LIBPERL_CCFLAGS=".." cargo build
+
 ## Contents
 
 Only types that are used by XS functions and macros are exported. Most of the

--- a/build/build.rs
+++ b/build/build.rs
@@ -42,7 +42,7 @@ impl Perl {
 fn build(perl: &Perl) {
     let mut gcc = gcc::Config::new();
 
-    let ccflags = perl.cfg("ccflags");
+    let ccflags = std::env::var("LIBPERL_CCFLAGS").unwrap_or_else(|_e| { perl.cfg("ccflags") });
     for flag in ccflags.split_whitespace() {
         gcc.flag(flag);
     }


### PR DESCRIPTION
Needed to modify the ccflags when compiling under darwin, as gcc yields fat files when multiple arch flags (x86_64 + i386) are passed, which seems to cause problems.