### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ This crate provides raw low-level bindings for Perl XS API.
 * Perl 5.18 or later
 * Perl packages:
   * Ouroboros
+  * File::ShareDir
+
+## Setup
+
+### Packages
+
+```bash
+cpan install Ouroboros
+cpan install File::ShareDir
+```
 
 ## Build
 

--- a/build/build.rs
+++ b/build/build.rs
@@ -40,7 +40,7 @@ impl Perl {
 }
 
 fn build(perl: &Perl) {
-    let mut gcc = gcc::Config::new();
+    let mut gcc = gcc::Build::new();
 
     let ccflags = std::env::var("LIBPERL_CCFLAGS").unwrap_or_else(|_e| { perl.cfg("ccflags") });
     for flag in ccflags.split_whitespace() {


### PR DESCRIPTION
This adds directions for getting build dependencies ready on the system, in addition to removing a compiler warning from the gcc crate